### PR TITLE
update jhipster-core to v1.2.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ nomnoml.sublime-workspace
 node_modules/
 bower_components/
 .tmp/
+.idea/

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
         "jquery": "3.1.0",
         "magnific-popup": "1.0.1",
         "icon-font.min": "https://cdn.linearicons.com/free/1.0.0/icon-font.min.css",
-        "pegjs_parser": "https://raw.githubusercontent.com/jhipster/jhipster-core/v1.1.5/lib/dsl/pegjs_parser.js",
+        "pegjs_parser": "https://raw.githubusercontent.com/jhipster/jhipster-core/v1.2.4/lib/dsl/pegjs_parser.js",
         "angular": "^1.5.8",
         "codemirror": "^5.0"
     },

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -9,6 +9,7 @@ var gulp = require("gulp"),
     rename = require("gulp-rename"),
     gulpIf = require('gulp-if'),
     inject = require('gulp-inject'),
+    babel = require('gulp-babel'),
     del = require('del'),
     browserSync = require('browser-sync').create(),
     reload      = browserSync.reload;
@@ -21,6 +22,8 @@ var config = {
     dist: 'dist/'
 }
 
+var babelTask = lazypipe()
+    .pipe(babel, {presets: ['es2015']});
 var initTask = lazypipe()
     .pipe(sourcemaps.init);
 var jsTask = lazypipe()
@@ -32,14 +35,15 @@ gulp.task('clean', function () {
     return del([config.dist], { dot: true });
 });
 
-
 gulp.task('build', ['clean', 'inject'], function() {
     var manifest = gulp.src('.tmp/rev-manifest.json');
 
     return gulp.src('index-dev.html')
         .pipe(rename("index.html"))
         //init sourcemaps
-        .pipe(useref({}, initTask))
+        .pipe(useref({}
+            ,lazypipe().pipe(function () {return gulpIf('bower_components/pegjs_parser/index.js', babelTask())})
+            ,initTask))
         .pipe(gulpIf('*.js', jsTask()))
         .pipe(gulpIf('*.css', cssTask()))
         .pipe(gulpIf('**/*.!(html)', rev()))

--- a/js/nomnoml/nomnoml.parser.custom.js
+++ b/js/nomnoml/nomnoml.parser.custom.js
@@ -4,7 +4,7 @@ var JDLParser = module.exports;
 nomnoml.parse = function (source){
 	function onlyCompilables(line){
 		var ok = line[0] !== '#' && line[0] !== '/' && line[0] !== '*'
-		return ok ? line : ''
+		return ok ? line.replace(/\/\/[^\n\r]*/mg, '') : ''
 	}
 	var isDirective = function (line){ return line.text[0] === '#' }
 	var lines = source.split('\n').map(function (s, i){

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
     "dagre": "0.4.5"
   },
   "devDependencies": {
+    "babel-preset-es2015": "6.18.0",
     "browser-sync": "2.12.5",
     "del": "2.2.0",
     "gulp": "3.9.1",
+    "gulp-babel": "6.1.2",
     "gulp-cssnano": "2.1.2",
     "gulp-if": "2.0.0",
     "gulp-inject": "4.0.0",


### PR DESCRIPTION
* Comments in separate lines were already handled properly, added handling following comments like in jhipster-core in function [removeInternalJDLComments](https://github.com/jhipster/jhipster-core/blob/9fdccc5fd71e9cdefd3b202a7b748bb05d5b02a7/lib/reader/jdl_reader.js#L23)
* If tried execute babel over all sources then runtime error `Global is undefined`, so executed babel only on problematic source

fix jhipster/jdl-studio#27