### PR TITLE
fix relationship names

### DIFF
--- a/partials/reference.html
+++ b/partials/reference.html
@@ -55,7 +55,7 @@ to
     </div>
     <ul class="options">
         <li>
-            <p><code class="highlighter-rouge">&lt;type&gt;</code> is the type of your relationship (OneToMany | ManyToOne| OneToOne | ManyToMany)</p>
+            <p><code class="highlighter-rouge">&lt;type&gt;</code> is the type of your relationship (OneToMany | ManyToOne | OneToOne | ManyToMany)</p>
         </li>
         <li>
             <p><code class="highlighter-rouge">&lt;from entity&gt;</code> is the name of the entity owner of the relationship,</p>

--- a/sample.jdl
+++ b/sample.jdl
@@ -78,15 +78,15 @@ relationship ManyToMany {
 
 // defining multiple OneToMany relationships with comments
 relationship OneToMany {
-	Employee{job} to Job,
+	Employee to Job{employee},
 	/**
 	* A relationship
 	*/
-	Department{employee} to
+	Department to
 	/**
 	* Another side of the same relationship
 	*/
-	Employee
+	Employee{department}
 }
 
 relationship ManyToOne {


### PR DESCRIPTION
In sample.jdl, shouldn't the relationship names be this way:
![image](https://user-images.githubusercontent.com/766263/60772089-4e232780-a0f1-11e9-9b22-19f7ea1e97af.png)


Before this PR, warnings are raised during import-jdl and comments such as '_A relationship_' and '_Another side of the same relationship_' are dropped.

![image](https://user-images.githubusercontent.com/766263/60771482-2760f300-a0e9-11e9-8143-e5f362c6d358.png)