### PR TITLE
Add git fetch to Auto Update Submodule

### DIFF
--- a/.github/workflows/update-jhipster-online.yml
+++ b/.github/workflows/update-jhipster-online.yml
@@ -34,7 +34,7 @@ jobs:
 
       # Update jdl-studio submodule
       - name: Update jdl-studio Submodule
-        run: cd src/main/resources/static/jdl-studio && git checkout gh-pages && git pull
+        run: cd src/main/resources/static/jdl-studio && git fetch && git checkout gh-pages && git pull
 
       # Create PR in jhipster-online with updated submodules
       - name: Create Pull Request


### PR DESCRIPTION
This adds git fetch to sync with the remote before checking out the submodules in jhipster-online sync action.

Related to https://github.com/jhipster/jhipster-online/pull/236