### PR TITLE
Add JHipster online authentication support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1386,6 +1386,12 @@
         "@types/yargs": "^13.0.0"
       }
     },
+    "@miragejs/pretender-node-polyfill": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@miragejs/pretender-node-polyfill/-/pretender-node-polyfill-0.1.2.tgz",
+      "integrity": "sha512-M/BexG/p05C5lFfMunxo/QcgIJnMT2vDVCd00wNqK2ImZONIlEETZwWJu1QtLxtmYlSHlCFl3JNzp0tLe7OJ5g==",
+      "dev": true
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -3072,6 +3078,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
       "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
     },
     "block-stream": {
       "version": "0.0.9",
@@ -5884,6 +5899,12 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
+    "fake-xml-http-request": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fake-xml-http-request/-/fake-xml-http-request-2.1.1.tgz",
+      "integrity": "sha512-Kn2WYYS6cDBS5jq/voOfSGCA0TafOYAUPbEp8mUVpD/DVV5bQIDjlq+MLLvNUokkbTpjBVlLDaM5PnX+PwZMlw==",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -5988,6 +6009,12 @@
         "loader-utils": "^1.2.3",
         "schema-utils": "^2.5.0"
       }
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
     },
     "filesize": {
       "version": "6.0.1",
@@ -6984,6 +7011,12 @@
       "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
       "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
     },
+    "inflected": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inflected/-/inflected-2.0.4.tgz",
+      "integrity": "sha512-HQPzFLTTUvwfeUH6RAGjD8cHS069mBqXG5n4qaxX7sJXBhVQrsGgF+0ZJGkSuN6a8pcUWB/GXStta11kKi/WvA==",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -7688,6 +7721,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         }
@@ -8330,10 +8364,130 @@
       "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz",
       "integrity": "sha1-DM8tiRZq8Ds2Y8eWU4t1rG4RTZ0="
     },
+    "lodash.assign": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
+      "dev": true
+    },
+    "lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+      "dev": true
+    },
+    "lodash.compact": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.compact/-/lodash.compact-3.0.1.tgz",
+      "integrity": "sha1-VAzjg3dFl1gHRx4WtKK6IeclbKU=",
+      "dev": true
+    },
+    "lodash.find": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
+      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
+      "dev": true
+    },
+    "lodash.forin": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.forin/-/lodash.forin-4.4.0.tgz",
+      "integrity": "sha1-XT8grlZAEfvog4H32YlJyclRlzE=",
+      "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=",
+      "dev": true
+    },
+    "lodash.invokemap": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.invokemap/-/lodash.invokemap-4.6.0.tgz",
+      "integrity": "sha1-F0jNpdiw74NpxOs+xUwh/rofLWI=",
+      "dev": true
+    },
+    "lodash.isempty": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=",
+      "dev": true
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
+    },
+    "lodash.isfunction": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
+      "dev": true
+    },
+    "lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
+      "dev": true
+    },
+    "lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+      "dev": true
+    },
+    "lodash.lowerfirst": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/lodash.lowerfirst/-/lodash.lowerfirst-4.3.1.tgz",
+      "integrity": "sha1-3jx7EuAsZSSgBZwvbLfFxSZVoT0=",
+      "dev": true
+    },
+    "lodash.map": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
+      "dev": true
+    },
+    "lodash.mapvalues": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
+      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
       "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
+    },
+    "lodash.pick": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
+      "dev": true
+    },
+    "lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -8366,6 +8520,18 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
+    },
+    "lodash.uniqby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
+      "dev": true
+    },
+    "lodash.values": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
+      "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c=",
+      "dev": true
     },
     "logform": {
       "version": "2.2.0",
@@ -8867,6 +9033,40 @@
           "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
           "dev": true
         }
+      }
+    },
+    "miragejs": {
+      "version": "0.1.40",
+      "resolved": "https://registry.npmjs.org/miragejs/-/miragejs-0.1.40.tgz",
+      "integrity": "sha512-7zxIcynzdS6425KZ2+TWD6F6DqESorulSDW2QBXf4iKyVn/J5vSielcubAK8sTKUefTPCrSRi7PwgNOb0JlmIg==",
+      "dev": true,
+      "requires": {
+        "@miragejs/pretender-node-polyfill": "^0.1.0",
+        "inflected": "^2.0.4",
+        "lodash.assign": "^4.2.0",
+        "lodash.camelcase": "^4.3.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.compact": "^3.0.1",
+        "lodash.find": "^4.6.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.forin": "^4.4.0",
+        "lodash.get": "^4.4.2",
+        "lodash.has": "^4.5.2",
+        "lodash.invokemap": "^4.6.0",
+        "lodash.isempty": "^4.4.0",
+        "lodash.isequal": "^4.5.0",
+        "lodash.isfunction": "^3.0.9",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.lowerfirst": "^4.3.1",
+        "lodash.map": "^4.6.0",
+        "lodash.mapvalues": "^4.6.0",
+        "lodash.pick": "^4.4.0",
+        "lodash.snakecase": "^4.1.1",
+        "lodash.uniq": "^4.5.0",
+        "lodash.uniqby": "^4.7.0",
+        "lodash.values": "^4.3.0",
+        "pretender": "^3.4.3"
       }
     },
     "mississippi": {
@@ -10974,6 +11174,16 @@
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
+    "pretender": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/pretender/-/pretender-3.4.3.tgz",
+      "integrity": "sha512-AlbkBly9R8KR+R0sTCJ/ToOeEoUMtt52QVCetui5zoSmeLOU3S8oobFsyPLm1O2txR6t58qDNysqPnA1vVi8Hg==",
+      "dev": true,
+      "requires": {
+        "fake-xml-http-request": "^2.1.1",
+        "route-recognizer": "^0.3.3"
+      }
+    },
     "pretty-bytes": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
@@ -11640,6 +11850,11 @@
         "symbol-observable": "^1.2.0"
       }
     },
+    "redux-thunk": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-2.3.0.tgz",
+      "integrity": "sha512-km6dclyFnmcvxhAcrQV2AkZmPQjzPDjgVlQtR0EQjxZPyJ0BnMf3in1ryuR8A2qU0HldVRfxYXbFSKlI3N7Slw=="
+    },
     "regenerate": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.1.tgz",
@@ -12029,6 +12244,12 @@
         "hash-base": "^3.0.0",
         "inherits": "^2.0.1"
       }
+    },
+    "route-recognizer": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/route-recognizer/-/route-recognizer-0.3.4.tgz",
+      "integrity": "sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==",
+      "dev": true
     },
     "rsvp": {
       "version": "4.8.5",
@@ -13958,6 +14179,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },
@@ -14241,6 +14463,7 @@
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1"
           }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1389,8 +1389,7 @@
     "@miragejs/pretender-node-polyfill": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/@miragejs/pretender-node-polyfill/-/pretender-node-polyfill-0.1.2.tgz",
-      "integrity": "sha512-M/BexG/p05C5lFfMunxo/QcgIJnMT2vDVCd00wNqK2ImZONIlEETZwWJu1QtLxtmYlSHlCFl3JNzp0tLe7OJ5g==",
-      "dev": true
+      "integrity": "sha512-M/BexG/p05C5lFfMunxo/QcgIJnMT2vDVCd00wNqK2ImZONIlEETZwWJu1QtLxtmYlSHlCFl3JNzp0tLe7OJ5g=="
     },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
@@ -3489,7 +3488,6 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/canvas/-/canvas-2.6.1.tgz",
       "integrity": "sha512-S98rKsPcuhfTcYbtF53UIJhcbgIAK533d1kJKMwsMwAIFgfd58MOyxRud3kktlzWiEkFliaJtvyZCBtud/XVEA==",
-      "dev": true,
       "requires": {
         "nan": "^2.14.0",
         "node-pre-gyp": "^0.11.0",
@@ -4492,7 +4490,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
       "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-      "dev": true,
       "requires": {
         "mimic-response": "^2.0.0"
       }
@@ -4513,8 +4510,7 @@
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "dev": true
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
     },
     "deep-is": {
       "version": "0.1.3",
@@ -4657,8 +4653,7 @@
     "detect-libc": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "dev": true
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -5902,8 +5897,7 @@
     "fake-xml-http-request": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/fake-xml-http-request/-/fake-xml-http-request-2.1.1.tgz",
-      "integrity": "sha512-Kn2WYYS6cDBS5jq/voOfSGCA0TafOYAUPbEp8mUVpD/DVV5bQIDjlq+MLLvNUokkbTpjBVlLDaM5PnX+PwZMlw==",
-      "dev": true
+      "integrity": "sha512-Kn2WYYS6cDBS5jq/voOfSGCA0TafOYAUPbEp8mUVpD/DVV5bQIDjlq+MLLvNUokkbTpjBVlLDaM5PnX+PwZMlw=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -6942,7 +6936,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.3.tgz",
       "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
-      "dev": true,
       "requires": {
         "minimatch": "^3.0.4"
       }
@@ -7014,8 +7007,7 @@
     "inflected": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inflected/-/inflected-2.0.4.tgz",
-      "integrity": "sha512-HQPzFLTTUvwfeUH6RAGjD8cHS069mBqXG5n4qaxX7sJXBhVQrsGgF+0ZJGkSuN6a8pcUWB/GXStta11kKi/WvA==",
-      "dev": true
+      "integrity": "sha512-HQPzFLTTUvwfeUH6RAGjD8cHS069mBqXG5n4qaxX7sJXBhVQrsGgF+0ZJGkSuN6a8pcUWB/GXStta11kKi/WvA=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -8367,110 +8359,92 @@
     "lodash.assign": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-      "dev": true
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
     "lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
-      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
-      "dev": true
+      "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.compact": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash.compact/-/lodash.compact-3.0.1.tgz",
-      "integrity": "sha1-VAzjg3dFl1gHRx4WtKK6IeclbKU=",
-      "dev": true
+      "integrity": "sha1-VAzjg3dFl1gHRx4WtKK6IeclbKU="
     },
     "lodash.find": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.find/-/lodash.find-4.6.0.tgz",
-      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E=",
-      "dev": true
+      "integrity": "sha1-ywcE1Hq3F4n/oN6Ll92Sb7iLE7E="
     },
     "lodash.flatten": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8=",
-      "dev": true
+      "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.forin": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.forin/-/lodash.forin-4.4.0.tgz",
-      "integrity": "sha1-XT8grlZAEfvog4H32YlJyclRlzE=",
-      "dev": true
+      "integrity": "sha1-XT8grlZAEfvog4H32YlJyclRlzE="
     },
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
-      "dev": true
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.has": {
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
-      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=",
-      "dev": true
+      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
     },
     "lodash.invokemap": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.invokemap/-/lodash.invokemap-4.6.0.tgz",
-      "integrity": "sha1-F0jNpdiw74NpxOs+xUwh/rofLWI=",
-      "dev": true
+      "integrity": "sha1-F0jNpdiw74NpxOs+xUwh/rofLWI="
     },
     "lodash.isempty": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.isempty/-/lodash.isempty-4.4.0.tgz",
-      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4=",
-      "dev": true
+      "integrity": "sha1-b4bL7di+TsmHvpqvM8loTbGzHn4="
     },
     "lodash.isequal": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
-      "dev": true
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
     },
     "lodash.isfunction": {
       "version": "3.0.9",
       "resolved": "https://registry.npmjs.org/lodash.isfunction/-/lodash.isfunction-3.0.9.tgz",
-      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw==",
-      "dev": true
+      "integrity": "sha512-AirXNj15uRIMMPihnkInB4i3NHeb4iBtNg9WRWuK2o31S+ePwwNmDPaTL3o7dTJ+VXNZim7rFs4rxN4YU1oUJw=="
     },
     "lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
-      "dev": true
+      "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
     },
     "lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
-      "dev": true
+      "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
     },
     "lodash.lowerfirst": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/lodash.lowerfirst/-/lodash.lowerfirst-4.3.1.tgz",
-      "integrity": "sha1-3jx7EuAsZSSgBZwvbLfFxSZVoT0=",
-      "dev": true
+      "integrity": "sha1-3jx7EuAsZSSgBZwvbLfFxSZVoT0="
     },
     "lodash.map": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.map/-/lodash.map-4.6.0.tgz",
-      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM=",
-      "dev": true
+      "integrity": "sha1-dx7Hg540c9nEzeKLGTlMNWL09tM="
     },
     "lodash.mapvalues": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.mapvalues/-/lodash.mapvalues-4.6.0.tgz",
-      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw=",
-      "dev": true
+      "integrity": "sha1-G6+lAF3p3W9PJmaMMMo3IwzJaJw="
     },
     "lodash.memoize": {
       "version": "4.1.2",
@@ -8480,14 +8454,12 @@
     "lodash.pick": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/lodash.pick/-/lodash.pick-4.4.0.tgz",
-      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM=",
-      "dev": true
+      "integrity": "sha1-UvBWEP/53tQiYRRB7R/BI6AwAbM="
     },
     "lodash.snakecase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
-      "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40=",
-      "dev": true
+      "integrity": "sha1-OdcUo1NXFHg3rv1ktdy7Fr7Nj40="
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -8524,14 +8496,12 @@
     "lodash.uniqby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz",
-      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI=",
-      "dev": true
+      "integrity": "sha1-2ZwHpmnp5tJOE2Lf4mbGdhavEwI="
     },
     "lodash.values": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-4.3.0.tgz",
-      "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c=",
-      "dev": true
+      "integrity": "sha1-o6bCsOvsxcLLocF+bmIP6BtT00c="
     },
     "logform": {
       "version": "2.2.0",
@@ -8922,8 +8892,7 @@
     "mimic-response": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-      "dev": true
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
     },
     "min-indent": {
       "version": "1.0.1",
@@ -9012,7 +8981,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
       "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-      "dev": true,
       "requires": {
         "minipass": "^2.9.0"
       },
@@ -9021,7 +8989,6 @@
           "version": "2.9.0",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-          "dev": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9030,8 +8997,7 @@
         "yallist": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         }
       }
     },
@@ -9039,7 +9005,6 @@
       "version": "0.1.40",
       "resolved": "https://registry.npmjs.org/miragejs/-/miragejs-0.1.40.tgz",
       "integrity": "sha512-7zxIcynzdS6425KZ2+TWD6F6DqESorulSDW2QBXf4iKyVn/J5vSielcubAK8sTKUefTPCrSRi7PwgNOb0JlmIg==",
-      "dev": true,
       "requires": {
         "@miragejs/pretender-node-polyfill": "^0.1.0",
         "inflected": "^2.0.4",
@@ -9205,7 +9170,6 @@
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.5.2.tgz",
       "integrity": "sha512-LbRIwS9BfkPvNwNHlsA41Q29kL2L/6VaOJ0qisM5lLWsTV3nP15abO5ITL6L81zqFhzjRKDAYjpcBcwM0AVvLQ==",
-      "dev": true,
       "requires": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -9216,7 +9180,6 @@
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
           "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
           "requires": {
             "ms": "^2.1.1"
           }
@@ -9392,7 +9355,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.11.0.tgz",
       "integrity": "sha512-TwWAOZb0j7e9eGaf9esRx3ZcLaE5tQ2lvYy1pb5IAaG1a2e2Kv5Lms1Y4hpj+ciXJRofIxxlt5haeQ/2ANeE0Q==",
-      "dev": true,
       "requires": {
         "detect-libc": "^1.0.2",
         "mkdirp": "^0.5.1",
@@ -9410,7 +9372,6 @@
           "version": "1.2.7",
           "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
           "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-          "dev": true,
           "requires": {
             "minipass": "^2.6.0"
           }
@@ -9419,7 +9380,6 @@
           "version": "2.9.0",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
           "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-          "dev": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9429,7 +9389,6 @@
           "version": "4.0.3",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.3.tgz",
           "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
-          "dev": true,
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -9438,14 +9397,12 @@
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         },
         "tar": {
           "version": "4.4.13",
           "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
           "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
-          "dev": true,
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -9459,8 +9416,7 @@
         "yallist": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
-          "dev": true
+          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
         }
       }
     },
@@ -9615,7 +9571,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.1.1.tgz",
       "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
-      "dev": true,
       "requires": {
         "npm-normalize-package-bin": "^1.0.1"
       }
@@ -9623,14 +9578,12 @@
     "npm-normalize-package-bin": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-1.0.1.tgz",
-      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
-      "dev": true
+      "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
     },
     "npm-packlist": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.8.tgz",
       "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
-      "dev": true,
       "requires": {
         "ignore-walk": "^3.0.1",
         "npm-bundled": "^1.0.1",
@@ -11178,7 +11131,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/pretender/-/pretender-3.4.3.tgz",
       "integrity": "sha512-AlbkBly9R8KR+R0sTCJ/ToOeEoUMtt52QVCetui5zoSmeLOU3S8oobFsyPLm1O2txR6t58qDNysqPnA1vVi8Hg==",
-      "dev": true,
       "requires": {
         "fake-xml-http-request": "^2.1.1",
         "route-recognizer": "^0.3.3"
@@ -11428,7 +11380,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "dev": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -11439,8 +11390,7 @@
         "strip-json-comments": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-          "dev": true
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         }
       }
     },
@@ -12248,8 +12198,7 @@
     "route-recognizer": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/route-recognizer/-/route-recognizer-0.3.4.tgz",
-      "integrity": "sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g==",
-      "dev": true
+      "integrity": "sha512-2+MhsfPhvauN1O8KaXpXAOfR/fwe8dnUXVM+xw7yt40lJRfPVQxV6yryZm0cgRvAj5fMF/mdRZbL2ptwbs5i2g=="
     },
     "rsvp": {
       "version": "4.8.5",
@@ -12681,14 +12630,12 @@
     "simple-concat": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "dev": true
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
     },
     "simple-get": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
       "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-      "dev": true,
       "requires": {
         "decompress-response": "^4.2.0",
         "once": "^1.3.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-scripts": "3.4.3",
     "reactjs-popup": "2.0.3",
     "redux": "4.0.5",
+    "redux-thunk": "^2.3.0",
     "typescript": "3.7.5"
   },
   "scripts": {
@@ -51,6 +52,7 @@
     ]
   },
   "devDependencies": {
-    "canvas": "^2.6.1"
+    "canvas": "^2.6.1",
+    "miragejs": "^0.1.40"
   }
 }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "react-scripts": "3.4.3",
     "reactjs-popup": "2.0.3",
     "redux": "4.0.5",
-    "redux-thunk": "^2.3.0",
+    "redux-thunk": "2.3.0",
     "typescript": "3.7.5"
   },
   "scripts": {
@@ -52,7 +52,7 @@
     ]
   },
   "devDependencies": {
-    "canvas": "^2.6.1",
-    "miragejs": "^0.1.40"
+    "canvas": "2.6.1",
+    "miragejs": "0.1.40"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,10 +12,12 @@
     "@types/react": "16.9.49",
     "@types/react-codemirror": "1.0.3",
     "@types/react-dom": "16.9.8",
+    "canvas": "2.6.1",
     "codemirror": "5.57.0",
     "dagre": "0.8.5",
     "jhipster-core": "7.3.4",
     "lodash.throttle": "4.1.1",
+    "miragejs": "0.1.40",
     "node-sass": "4.14.1",
     "nomnoml": "0.10.0",
     "react": "16.13.1",
@@ -51,9 +53,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "devDependencies": {
-    "canvas": "2.6.1",
-    "miragejs": "0.1.40"
   }
 }

--- a/src/App.scss
+++ b/src/App.scss
@@ -218,7 +218,7 @@ header {
   }
 }
 
-@media only screen and (max-width: 1080px) {
+@media only screen and (max-width: 1200px) {
   header {
     .tools.center {
       display: none;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,15 @@
 import React from "react";
+import { Server } from "miragejs"
+
+import mocksConfig from "./mocks";
 import Sidebar from "./components/sidebar/Sidebar";
 import Header from "./components/Header";
 import Studio from "./components/studio/Studio";
 import "./App.scss";
+
+if (process.env.NODE_ENV !== 'production') {
+  new Server(mocksConfig)
+}
 
 function App() {
   return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,9 @@
 import React from "react";
-import { Server } from "miragejs"
 
-import mocksConfig from "./mocks";
 import Sidebar from "./components/sidebar/Sidebar";
 import Header from "./components/Header";
 import Studio from "./components/studio/Studio";
 import "./App.scss";
-
-if (process.env.NODE_ENV !== 'production') {
-  new Server(mocksConfig)
-}
 
 function App() {
   return (

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -1,5 +1,5 @@
-import { createStore } from "redux";
-import { combineReducers } from "redux";
+import { createStore, combineReducers, applyMiddleware } from "redux";
+import thunk from 'redux-thunk';
 import { studio, StudioState } from "./components/studio/StudioReducer";
 import { jhOnline, JhOnlineState } from "./components/JhOnlineReducer";
 
@@ -13,4 +13,6 @@ export const rootReducer = combineReducers<IRootState>({
   jhOnline,
 });
 
-export const store = createStore(rootReducer);
+export const middlewares = applyMiddleware(thunk)
+
+export const store = createStore(rootReducer, middlewares);

--- a/src/Store.ts
+++ b/src/Store.ts
@@ -1,5 +1,5 @@
 import { createStore, combineReducers, applyMiddleware } from "redux";
-import thunk from 'redux-thunk';
+import thunk from "redux-thunk";
 import { studio, StudioState } from "./components/studio/StudioReducer";
 import { jhOnline, JhOnlineState } from "./components/JhOnlineReducer";
 
@@ -13,6 +13,6 @@ export const rootReducer = combineReducers<IRootState>({
   jhOnline,
 });
 
-export const middlewares = applyMiddleware(thunk)
+export const middlewares = applyMiddleware(thunk);
 
 export const store = createStore(rootReducer, middlewares);

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable jsx-a11y/anchor-is-valid */
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { connect } from "react-redux";
 import LineIcon from "react-lineicons";
 import logo from "../resources/logo-jhipster.png";
 import { IRootState } from "../Store";
-import { setJDL } from "./JhOnlineReducer";
+import { initAuthentication, setJDL, loadJdl } from "./JhOnlineReducer";
 import {
   setSidebar,
   setCode,
@@ -26,12 +26,14 @@ export interface IHeaderProp extends StateProps, DispatchProps {}
 export function Header({
   code,
   isStorageReadOnly,
+  initAuthentication,
   jhOnline,
   isLightMode,
   ranker,
   direction,
   setCode,
   setJDL,
+  loadJdl,
   setSidebar,
   toggleLightMode,
   toggleRanker,
@@ -40,6 +42,19 @@ export function Header({
   const [uploadPopup, setUploadPopup] = useState(false);
   const [templatePopup, setTemplatePopup] = useState(false);
   const [template, setTemplate] = useState("");
+
+  useEffect(() => {
+    if (!jhOnline.authenticated) {
+      initAuthentication()
+    }
+  }, [initAuthentication, jhOnline.authenticated])
+
+  useEffect(() => {
+    if (!jhOnline.jdlId) {
+      location.hash = '/' // eslint-disable-line no-restricted-globals
+    }
+    loadJdl()
+  }, [jhOnline.jdlId, loadJdl])
 
   const toggleSidebar = (page: string) => () => {
     setSidebar(page);
@@ -185,11 +200,11 @@ export function Header({
               <select
                 className="jdl-select"
                 value={jhOnline.jdlId}
-                onChange={setJDL}
+                onChange={(e) => setJDL(e.target.value)}
               >
                 <option value="">&lt;Create new JDL Model&gt;</option>
                 {jhOnline.jdls.map((jdl) => (
-                  <option value={jdl.id}>{jdl.name}</option>
+                  <option key={jdl.id} value={jdl.id}>{jdl.name}</option>
                 ))}
               </select>
               {jhOnline.startLoadingFlag ? (
@@ -297,11 +312,13 @@ const mapStateToProps = ({ studio, jhOnline }: IRootState) => ({
 
 const mapDispatchToProps = {
   setJDL,
+  loadJdl,
   setSidebar,
   setCode,
   toggleLightMode,
   toggleRanker,
   toggleDirection,
+  initAuthentication,
 };
 
 type StateProps = ReturnType<typeof mapStateToProps>;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -92,6 +92,10 @@ export function Header({
 
   const confirmCreateNewJdl = () => {};
 
+  const handleChangeJDLModel = (event) => {
+    setJDL(event.target.value)
+  }
+
   return (
     <>
       <header className={`${isLightMode ? "light-theme" : "dark-theme"}`}>
@@ -200,7 +204,7 @@ export function Header({
               <select
                 className="jdl-select"
                 value={jhOnline.jdlId}
-                onChange={(e) => setJDL(e.target.value)}
+                onChange={handleChangeJDLModel}
               >
                 <option value="">&lt;Create new JDL Model&gt;</option>
                 {jhOnline.jdls.map((jdl) => (

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -25,7 +25,6 @@ export interface IHeaderProp extends StateProps, DispatchProps {}
 
 export function Header({
   code,
-  isStorageReadOnly,
   initAuthentication,
   jhOnline,
   isLightMode,
@@ -45,16 +44,16 @@ export function Header({
 
   useEffect(() => {
     if (!jhOnline.authenticated) {
-      initAuthentication()
+      initAuthentication();
     }
-  }, [initAuthentication, jhOnline.authenticated])
+  }, [jhOnline.authenticated, initAuthentication]);
 
   useEffect(() => {
     if (!jhOnline.jdlId) {
-      location.hash = '/' // eslint-disable-line no-restricted-globals
+      location.hash = "/"; // eslint-disable-line no-restricted-globals
     }
-    loadJdl()
-  }, [jhOnline.jdlId, loadJdl])
+    loadJdl();
+  }, [jhOnline.jdlId, loadJdl]);
 
   const toggleSidebar = (page: string) => () => {
     setSidebar(page);
@@ -93,8 +92,8 @@ export function Header({
   const confirmCreateNewJdl = () => {};
 
   const handleChangeJDLModel = (event) => {
-    setJDL(event.target.value)
-  }
+    setJDL(event.target.value);
+  };
 
   return (
     <>
@@ -117,25 +116,6 @@ export function Header({
             JDL-Studio
           </a>
         </div>
-        {isStorageReadOnly ? (
-          <span className="storage-status" ng-show="isStorageReadOnly">
-            View mode, changes are not saved.
-            <a
-              // onClick="app.saveViewModeToStorage()"
-              title="Save this diagram to localStorage"
-              className="link"
-            >
-              save
-            </a>
-            <a
-              // onClick="app.exitViewMode()"
-              title="Discard this diagram"
-              className="link"
-            >
-              close
-            </a>
-          </span>
-        ) : null}
         <div className="tools center">
           <a onClick={toggleLightMode} title="Toggle theme" className="link">
             {isLightMode ? <LineIcon name="night" /> : <LineIcon name="sun" />}
@@ -185,7 +165,7 @@ export function Header({
               Please sign in for more features!
             </a>
           ) : null}
-          {!jhOnline.insideJhOnline ? (
+          {!jhOnline.insideJhOnline && !jhOnline.authenticated ? (
             <a
               id="signin"
               className="special"
@@ -208,7 +188,9 @@ export function Header({
               >
                 <option value="">&lt;Create new JDL Model&gt;</option>
                 {jhOnline.jdls.map((jdl) => (
-                  <option key={jdl.id} value={jdl.id}>{jdl.name}</option>
+                  <option key={jdl.id} value={jdl.id}>
+                    {jdl.name}
+                  </option>
                 ))}
               </select>
               {jhOnline.startLoadingFlag ? (
@@ -221,7 +203,7 @@ export function Header({
                   className="link"
                   onClick={confirmCreateNewJdl}
                 >
-                  <LineIcon name="file-add" />
+                  <LineIcon name="save" />
                 </a>
               )}
               <a onClick={goToManageJdls} className="link" title="Manage JDLs">
@@ -298,7 +280,7 @@ export function Header({
         className={`${isLightMode ? "light-theme" : "dark-theme"}`}
       />
       <WarningPopup
-        open={!jhOnline.insideJhOnline}
+        open={!jhOnline.insideJhOnline && !jhOnline.authenticated}
         className={`${isLightMode ? "light-theme" : "dark-theme"}`}
       />
     </>
@@ -307,7 +289,6 @@ export function Header({
 
 const mapStateToProps = ({ studio, jhOnline }: IRootState) => ({
   code: studio.code,
-  isStorageReadOnly: studio.isStorageReadOnly,
   jhOnline: jhOnline,
   isLightMode: studio.isLightMode,
   ranker: studio.ranker,

--- a/src/components/JhOnlineReducer.ts
+++ b/src/components/JhOnlineReducer.ts
@@ -1,4 +1,6 @@
+import { Server } from "miragejs";
 import { setCode } from "./studio/StudioReducer";
+import mocksConfig from "../mocks";
 
 export const ACTION_TYPES = {
   SET_JDL: "jhOnline/SET_JDL",
@@ -18,7 +20,12 @@ const initialState = {
   startLoadingFlag: false,
 };
 
-const server_api = '';
+const server_api = "";
+
+// setup a mock server when running standalone and not in production mode
+if (process.env.NODE_ENV !== "production" && !isInJHOnline()) {
+  new Server(mocksConfig);
+}
 
 export type JhOnlineState = Readonly<typeof initialState>;
 
@@ -48,129 +55,176 @@ export const jhOnline = (
 };
 
 export const setJDL = (data) => {
-  return ({
+  return {
     type: ACTION_TYPES.SET_JDL,
     data,
-  })
+  };
+};
+
+function getAuthHeader() {
+  const authToken = JSON.parse(
+    localStorage.getItem("jhi-authenticationtoken") ||
+      sessionStorage.getItem("jhi-authenticationtoken") ||
+      "null"
+  );
+  if (authToken) {
+    return {
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+      },
+    };
+  }
+  return null;
+}
+
+export const initAuthentication = () => async (dispatch) => {
+  const authHeader = getAuthHeader();
+  if (authHeader || process.env.NODE_ENV === "development") {
+    try {
+      const res = await fetch(`${server_api}/api/account`, authHeader || {});
+      const json = await res.json();
+      if (res.ok) {
+        dispatch({
+          type: ACTION_TYPES.SET_AUTH,
+          data: {
+            authenticated: true,
+            username: json.login,
+          },
+        });
+        const jdlId = getViewHash();
+        if (jdlId !== "") {
+          dispatch({
+            type: ACTION_TYPES.SET_JDL,
+            data: jdlId,
+          });
+          dispatch(loadJdl());
+        }
+        dispatch(fetchAllJDLsMetadata());
+      } else {
+        handleAuthError(`${res.statusText}: ${json.detail}`, dispatch);
+      }
+    } catch (e) {
+      handleAuthError(e, dispatch);
+    }
+  } else {
+    console.log("Auth token not found");
+  }
+};
+
+export const fetchAllJDLsMetadata = () => async (dispatch) => {
+  const authHeader = getAuthHeader();
+  if (authHeader) {
+    try {
+      const res = await fetch(`${server_api}/api/jdl-metadata`, authHeader);
+      const json = await res.json();
+      if (res.ok) {
+        dispatch({
+          type: ACTION_TYPES.SET_JDL_META,
+          data: json,
+        });
+        var viewHash = getViewHash();
+        if (viewHash === "") {
+          return;
+        }
+        json.forEach((it) => {
+          if (viewHash === it.id) {
+            dispatch({
+              type: ACTION_TYPES.SET_JDL,
+              data: viewHash,
+            });
+          }
+        });
+      } else {
+        handleJDLMetadataError(`${res.statusText}: ${json.detail}`, dispatch);
+      }
+    } catch (e) {
+      handleJDLMetadataError(e, dispatch);
+    }
+  } else {
+    console.log("Auth token not found");
+  }
 };
 
 export const loadJdl = () => async (dispatch, getState) => {
   const state = getState().jhOnline as JhOnlineState;
   if (!state.jdlId) {
-    dispatch(fetchAllJDLsMetadata());
-    dispatch({
-      type: ACTION_TYPES.SET_JDL,
-      data: "",
-    });
-    setViewHash("");
-    return
+    handleJDLError("JDL not set", dispatch);
+    return;
   }
-
-  try {
-    const res = await fetch(`${server_api}/api/jdl/${state.jdlId}`);
-    const json = await res.json();
-    let content = '';
-    if (json.content !== undefined) {
-      content = json.content;
-    }
-    dispatch(setCode(content));
-    setViewHash(state.jdlId);
-  } catch (e) {
-    console.error(e);
-    dispatch(fetchAllJDLsMetadata());
-    dispatch({
-      type: ACTION_TYPES.SET_JDL,
-      data: "",
-    });
-    setViewHash("");
-  }
-};
-
-export const fetchAllJDLsMetadata = () => async (dispatch, getState) => {
-  try {
-    const res = await fetch(`${server_api}/api/jdl-metadata`);
-    const json = await res.json();
-    dispatch({
-      type: ACTION_TYPES.SET_JDL_META,
-      data: json,
-    });
-    var viewHash = getViewHash();
-    if (viewHash === "") {
-      return;
-    }
-    for (var index = 0; index < json.length; ++index) {
-      if (viewHash === json[index].id) {
-        dispatch({
-          type: ACTION_TYPES.SET_JDL,
-          data: viewHash,
-        });
-      }
-    }
-  } catch (e) {
-    console.error(e);
-  }
-};
-
-export const initAuthentication = () => async (dispatch, getState) => {
-  const authToken = JSON.parse(
-    localStorage.getItem('jhi-authenticationtoken') ||
-    sessionStorage.getItem('jhi-authenticationtoken') ||
-    'null'
-  );
-  if (authToken || process.env.NODE_ENV === "development") {
+  const authHeader = getAuthHeader();
+  if (authHeader) {
     try {
-      const res = await fetch(`${server_api}/api/account`, {
-        headers: {
-          Authorization: `Bearer ${authToken}`,
-        },
-      });
+      const res = await fetch(
+        `${server_api}/api/jdl/${state.jdlId}`,
+        authHeader
+      );
       const json = await res.json();
-      dispatch({
-        type: ACTION_TYPES.SET_AUTH,
-        data: {
-          authenticated: true,
-          username: json.login,
-        },
-      });
-      const jdlId = getViewHash();
-      if (jdlId !== "") {
-        dispatch({
-          type: ACTION_TYPES.SET_JDL,
-          data: jdlId,
-        });
-        dispatch(loadJdl());
+      if (res.ok) {
+        let content = "";
+        if (json.content !== undefined) {
+          content = json.content;
+        }
+        dispatch(setCode(content));
+        setViewHash(state.jdlId);
+      } else {
+        handleJDLError(`${res.statusText}: ${json.detail}`, dispatch);
       }
-      dispatch(fetchAllJDLsMetadata());
     } catch (e) {
-      console.error('Cannot get authentication token', e);
-      dispatch({
-        type: ACTION_TYPES.SET_AUTH,
-        data: {
-          authenticated: false,
-          username: "",
-        },
-      });
+      handleJDLError(e, dispatch);
     }
+  } else {
+    console.log("Auth token not found");
   }
 };
+
+function handleAuthError(e, dispatch) {
+  console.error("Cannot get authentication token", e);
+  dispatch({
+    type: ACTION_TYPES.SET_AUTH,
+    data: {
+      authenticated: false,
+      username: "",
+    },
+  });
+}
+
+function handleJDLMetadataError(e, dispatch) {
+  console.error("Error fetching JDL metadata", e);
+  dispatch({
+    type: ACTION_TYPES.SET_JDL_META,
+    data: [],
+  });
+}
+
+function handleJDLError(e, dispatch) {
+  console.error("Error fetching JDL", e);
+  dispatch(fetchAllJDLsMetadata());
+  dispatch({
+    type: ACTION_TYPES.SET_JDL,
+    data: "",
+  });
+  setViewHash("");
+}
 
 function getViewHash() {
   const hash = location.hash; // eslint-disable-line no-restricted-globals
   if (!hash) {
-    return '';
+    return "";
   }
   return hash.substring(8, hash.length);
 }
 
 function setViewHash(jdlId) {
-  // TODO this doesn't seem to work
   if (!jdlId) {
-    location.hash = '/'// eslint-disable-line no-restricted-globals
-    return
+    location.hash = "/"; // eslint-disable-line no-restricted-globals
+    return;
   }
   location.hash = "/view/" + jdlId; // eslint-disable-line no-restricted-globals
 }
 
 function isInJHOnline() {
-  return window.location.href.indexOf("www.jhipster.tech/jdl-studio") === -1;
+  if (process.env.NODE_ENV === "production") {
+    return !window.location.href.includes("www.jhipster.tech/jdl-studio");
+  }
+  return window.location.href.includes("localhost:8080/jdl-studio/");
 }

--- a/src/components/studio/StudioReducer.ts
+++ b/src/components/studio/StudioReducer.ts
@@ -94,7 +94,7 @@ export const studio = (
 };
 
 export const reloadStorage: () => void = () => (dispatch) => {
-  storage = buildStorage(location.hash); // eslint-disable-line no-restricted-globals
+  storage = buildStorage(location.hash, defaultSource); // eslint-disable-line no-restricted-globals
   dispatch(setCode(storage.read()));
   dispatch(setStorageStat(storage.isReadonly));
 };
@@ -152,7 +152,8 @@ function buildStorage(locationHash, defaultSource = "") {
   if (locationHash.substring(0, 7) === "#/view/") {
     return {
       read: function (): string {
-        return urlDecode(locationHash.substring(7));
+        const hash = urlDecode(locationHash.substring(7));
+        return hash ? localStorage[STORAGE_KEY] : defaultSource;
       },
       save: function (source: string) {},
       moveToLocalStorage: function (txt: string) {
@@ -166,7 +167,7 @@ function buildStorage(locationHash, defaultSource = "") {
       return localStorage[STORAGE_KEY] || defaultSource;
     },
     save: function (source: string) {
-      localStorage[STORAGE_KEY] = source;
+      localStorage[STORAGE_KEY] = source || defaultSource;
     },
     moveToLocalStorage: function (txt) {},
     isReadonly: false,

--- a/src/components/studio/StudioReducer.ts
+++ b/src/components/studio/StudioReducer.ts
@@ -167,7 +167,7 @@ function buildStorage(locationHash, defaultSource = "") {
       return localStorage[STORAGE_KEY] || defaultSource;
     },
     save: function (source: string) {
-      localStorage[STORAGE_KEY] = source || defaultSource;
+      localStorage[STORAGE_KEY] = source;
     },
     moveToLocalStorage: function (txt) {},
     isReadonly: false,

--- a/src/components/studio/StudioReducer.ts
+++ b/src/components/studio/StudioReducer.ts
@@ -20,7 +20,7 @@ const DEF_ERROR = {
 const STORAGE_KEY = "jdlstudio.lastSource";
 const THEME_KEY = "jdlstudio.lightMode";
 // this object stores the JDL code to local storage
-let storage = buildStorage(location.hash, defaultSource); // eslint-disable-line no-restricted-globals
+let storage = buildStorage(defaultSource);
 
 const rankers = ["tight-tree", "longest-path"];
 const directions = ["down", "right"];
@@ -94,7 +94,7 @@ export const studio = (
 };
 
 export const reloadStorage: () => void = () => (dispatch) => {
-  storage = buildStorage(location.hash, defaultSource); // eslint-disable-line no-restricted-globals
+  storage = buildStorage(defaultSource);
   dispatch(setCode(storage.read()));
   dispatch(setStorageStat(storage.isReadonly));
 };
@@ -144,24 +144,7 @@ export const setStorageStat = (data) => ({
   data,
 });
 
-function urlDecode(encoded) {
-  return decodeURIComponent(encoded.replace(/\+/g, " "));
-}
-
-function buildStorage(locationHash, defaultSource = "") {
-  if (locationHash.substring(0, 7) === "#/view/") {
-    return {
-      read: function (): string {
-        const hash = urlDecode(locationHash.substring(7));
-        return hash ? localStorage[STORAGE_KEY] : defaultSource;
-      },
-      save: function (source: string) {},
-      moveToLocalStorage: function (txt: string) {
-        localStorage[STORAGE_KEY] = txt;
-      },
-      isReadonly: true,
-    };
-  }
+function buildStorage(defaultSource = "") {
   return {
     read: function (): string {
       return localStorage[STORAGE_KEY] || defaultSource;

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,0 +1,42 @@
+import { AnyFactories, AnyModels } from 'miragejs/-types'
+import { ServerConfig } from 'miragejs/server'
+
+export default {
+  routes() {
+    this.namespace = "api"
+
+    this.get('/account', () => ({
+      id: 0,
+      login: 'user@jhipster.com',
+      firstName: 'JHiptser',
+      lastName: 'JHiptser',
+      email: 'user@jhipster.com',
+      imageUrl: null,
+      activated: true,
+      langKey: 'en',
+      createdBy: 'anonymousUser',
+      createdDate: '2020-09-14T10:20:59Z',
+      lastModifiedBy: 'anonymousUser',
+      lastModifiedDate: '2020-09-14T10:20:59Z',
+      authorities: ['ROLE_USER']
+    }))
+
+    this.get('/jdl-metadata', () => (
+      [{
+        id: '5492f5eb-3b80-40bf-abed-2d9583b6381f',
+        name: 'test',
+        createdDate: '2020-09-14T13:10:44Z',
+        updatedDate: '2020-09-14T13:10:44Z',
+        isPublic: false
+      }]
+    ))
+
+    this.get('jdl/:jdlId', (_, request) => {
+      const jdlId = request.params.id
+      return {
+        name:`test-${jdlId}`,
+        content: "entity Region {\n\tregionName String\n}\n\nentity Country {\n\tcountryName String\n}\n\n"
+      }
+    })
+  },
+} as ServerConfig<AnyModels, AnyFactories>

--- a/src/mocks/index.ts
+++ b/src/mocks/index.ts
@@ -1,42 +1,57 @@
-import { AnyFactories, AnyModels } from 'miragejs/-types'
-import { ServerConfig } from 'miragejs/server'
+import { AnyFactories, AnyModels } from "miragejs/-types";
+import { ServerConfig } from "miragejs/server";
 
 export default {
   routes() {
-    this.namespace = "api"
+    this.namespace = "api";
 
-    this.get('/account', () => ({
+    this.get("/account", () => ({
       id: 0,
-      login: 'user@jhipster.com',
-      firstName: 'JHiptser',
-      lastName: 'JHiptser',
-      email: 'user@jhipster.com',
+      login: "user@jhipster.com",
+      firstName: "JHiptser",
+      lastName: "JHiptser",
+      email: "user@jhipster.com",
       imageUrl: null,
       activated: true,
-      langKey: 'en',
-      createdBy: 'anonymousUser',
-      createdDate: '2020-09-14T10:20:59Z',
-      lastModifiedBy: 'anonymousUser',
-      lastModifiedDate: '2020-09-14T10:20:59Z',
-      authorities: ['ROLE_USER']
-    }))
+      langKey: "en",
+      createdBy: "anonymousUser",
+      createdDate: "2020-09-14T10:20:59Z",
+      lastModifiedBy: "anonymousUser",
+      lastModifiedDate: "2020-09-14T10:20:59Z",
+      authorities: ["ROLE_USER"],
+    }));
 
-    this.get('/jdl-metadata', () => (
-      [{
-        id: '5492f5eb-3b80-40bf-abed-2d9583b6381f',
-        name: 'test',
-        createdDate: '2020-09-14T13:10:44Z',
-        updatedDate: '2020-09-14T13:10:44Z',
-        isPublic: false
-      }]
-    ))
+    this.get("/jdl-metadata", () => [
+      {
+        id: "5492f5eb-3b80-40bf-abed-2d9583b6381f",
+        name: "test",
+        createdDate: "2020-09-14T13:10:44Z",
+        updatedDate: "2020-09-14T13:10:44Z",
+        isPublic: false,
+      },
+      {
+        id: "5492f5eb-3b80-40bf-abed-2d9583b6381g",
+        name: "test2",
+        createdDate: "2020-09-14T13:10:44Z",
+        updatedDate: "2020-09-14T13:10:44Z",
+        isPublic: false,
+      },
+    ]);
 
-    this.get('jdl/:jdlId', (_, request) => {
-      const jdlId = request.params.id
+    this.get("jdl/:jdlId", (_, request) => {
+      const jdlId = request.params.jdlId;
       return {
-        name:`test-${jdlId}`,
-        content: "entity Region {\n\tregionName String\n}\n\nentity Country {\n\tcountryName String\n}\n\n"
-      }
-    })
+        name: `test-${jdlId}`,
+        content: `
+// ${jdlId}
+entity Region {
+  regionName String
+}
+entity Country {
+  countryName String
+}
+          `,
+      };
+    });
   },
-} as ServerConfig<AnyModels, AnyFactories>
+} as ServerConfig<AnyModels, AnyFactories>;


### PR DESCRIPTION
fix #108 

# Add jhipster online authentication

## Current state

- The app works in a faked auth state thanks to [miragejs](https://miragejs.com/) (we probably need to improve the mocks in order to cover a large part of use cases)
- Fixed some problems with the "online" status 
  - [x] The user can load his JDL Models
  - [x] JDL Models are properly displayed inside the app

## What's missing

- [x] Real test case with the real jhipster online platform