### PR TITLE
Add git fetch before checkout of the gh-pages branch

### DIFF
--- a/.github/workflows/update-jhipster-online.yml
+++ b/.github/workflows/update-jhipster-online.yml
@@ -34,7 +34,7 @@ jobs:
 
       # Update jdl-studio submodule
       - name: Update jdl-studio Submodule
-        run: cd src/main/resources/static/jdl-studio && git fetch && git checkout gh-pages && git pull
+        run: cd src/main/resources/static/jdl-studio && git remote update && git fetch && git checkout --track origin/gh-pages && git pull
 
       # Create PR in jhipster-online with updated submodules
       - name: Create Pull Request


### PR DESCRIPTION
This syncs with the remote by executing git fetch before checkout of the gh-pages branch in the submodule. 

*Note*: This is a duplicate PR to update gh-pages and test it out.

Related to Related to https://github.com/jhipster/jhipster-online/pull/236