### PR TITLE
Fix issue #117

### DIFF
--- a/src/components/studio/JDLToNoml.ts
+++ b/src/components/studio/JDLToNoml.ts
@@ -204,13 +204,13 @@ function getCardinality(cardinality) {
   switch (cardinality) {
     case "one-to-many":
     case "OneToMany":
-      return "(1..*) -o";
+      return "o- (1..*)";
     case "OneToOne":
     case "one-to-one":
-      return "(1..1) -";
+      return "- (1..1)";
     case "ManyToOne":
     case "many-to-one":
-      return "(*..1) o-";
+      return "(1..*) -o";
     case "ManyToMany":
     case "many-to-many":
       return "(*..*) o-o";


### PR DESCRIPTION
The diamond represents an aggregation in UML diagrams, but was depicted in the wrong end of the One-to-Many / Many-to-One relation, which is confusing. The proposed fix returns jdl-studio to the way it draws diagrams in previous releases.